### PR TITLE
Integrates prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ npm run build
 # This step will override the @grnsft/if-unofficial-plugins package with this repository content
 npm link
 
+kubectl port-forward -n monitoring svc/prometheus-operated 9090
+
 ie --manifest kepler-manifest.yml
 ```
 

--- a/kepler-manifest.yml
+++ b/kepler-manifest.yml
@@ -1,9 +1,9 @@
 name: kepler-test
 description:
 tags:
-aggregation:
-  metrics:
-    - 'carbon'
+  # aggregation:
+  #   metrics:
+  #     - 'carbon'
   type: 'both'
 initialize:
   plugins:
@@ -15,3 +15,11 @@ tree:
     child-1:
       pipeline:
         - kepler-importer
+      config:
+        kepler-importer:
+          kepler-observation-window: 3600
+          prometheus-endpoint: http://localhost:9090
+          kepler-namespace: falco
+      inputs:
+        - timestamp: '2024-03-21T00:00:00Z'
+          duration: 10800

--- a/kepler-manifest.yml
+++ b/kepler-manifest.yml
@@ -6,6 +6,8 @@ tags:
   #     - 'carbon'
   type: 'both'
 initialize:
+  outputs:
+    - yaml
   plugins:
     'kepler-importer':
       path: '@grnsft/if-unofficial-plugins'

--- a/kepler-manifest.yml
+++ b/kepler-manifest.yml
@@ -21,7 +21,8 @@ tree:
         kepler-importer:
           kepler-observation-window: 3600
           prometheus-endpoint: http://localhost:9090
-          kepler-namespace: falco
+          container-namespace: falco
+          container-name: falco
       inputs:
         - timestamp: '2024-03-21T00:00:00Z'
           duration: 10800

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "dayjs": "^1.11.10",
         "dotenv": "16.3.1",
         "js-yaml": "^4.1.0",
+        "prometheus-query": "^3.4.0",
         "typescript": "^5.1.6",
         "typescript-cubic-spline": "^1.0.1",
         "zod": "^3.22.4"
@@ -9826,6 +9827,14 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/prometheus-query": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/prometheus-query/-/prometheus-query-3.4.0.tgz",
+      "integrity": "sha512-PGNwYVjXxenfj2PR4FKEUv5O4XO8ciHT92GX83J5ZJm5ki3YzLLiv+TfbmQSUxvHcXofLg9PYH6CBCSplcvr9g==",
+      "dependencies": {
+        "axios": "^1.6.0"
       }
     },
     "node_modules/prompts": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "dayjs": "^1.11.10",
     "dotenv": "16.3.1",
     "js-yaml": "^4.1.0",
+    "prometheus-query": "^3.4.0",
     "typescript": "^5.1.6",
     "typescript-cubic-spline": "^1.0.1",
     "zod": "^3.22.4"

--- a/src/lib/kepler-importer/index.ts
+++ b/src/lib/kepler-importer/index.ts
@@ -1,5 +1,7 @@
+import {assert} from 'console';
 import {PluginInterface} from '../../interfaces';
 import {ConfigParams, PluginParams} from '../../types';
+import {PrometheusDriver, SampleValue} from 'prometheus-query';
 
 export const KeplerPlugin = (globalConfig: ConfigParams): PluginInterface => {
   const metadata = {
@@ -9,13 +11,34 @@ export const KeplerPlugin = (globalConfig: ConfigParams): PluginInterface => {
   /**
    * Execute's strategy description here.
    */
-  const execute = async (inputs: PluginParams[]): Promise<PluginParams[]> => {
-    return inputs.map(input => {
-      // your logic here
-      globalConfig;
+  const execute = async (
+    inputs: PluginParams[],
+    config?: ConfigParams
+  ): Promise<PluginParams[]> => {
+    if (config === undefined) {
+      throw new Error('Config for Kepler plugin must be provided.');
+    }
 
-      return input;
-    });
+    globalConfig;
+    const endpoint = config['prometheus-endpoint'];
+    const step = config['kepler-observation-window'];
+    const namespace = config['kepler-namespace'];
+
+    const outputs = [];
+    for (const input of inputs) {
+      const start = new Date(input['timestamp']);
+      const duration = input['duration'];
+      const end = new Date(start.getTime() + duration * 1000 - 1);
+
+      const serie = await prometheus(endpoint, start, end, step, namespace);
+      const energy = serie.values.map((sample: SampleValue) => ({
+        timestamp: sample.time,
+        energy: sample.value,
+        duration: step,
+      }));
+      outputs.push(energy);
+    }
+    return outputs;
   };
 
   return {
@@ -23,3 +46,20 @@ export const KeplerPlugin = (globalConfig: ConfigParams): PluginInterface => {
     execute,
   };
 };
+
+async function prometheus(
+  endpoint: string,
+  start: Date,
+  end: Date,
+  step: number,
+  namespace: string
+) {
+  const prom = new PrometheusDriver({endpoint: endpoint, baseURL: '/api/v1'});
+  const promql = `sum(increase(kepler_container_joules_total{container_namespace="${namespace}"}[${step}s]))`;
+  const query = prom.rangeQuery(promql, start, end, step);
+  const res = await query;
+
+  assert(res.result.length === 1);
+  const serie = res.result[0];
+  return serie;
+}

--- a/src/lib/kepler-importer/index.ts
+++ b/src/lib/kepler-importer/index.ts
@@ -38,7 +38,7 @@ export const KeplerPlugin = (globalConfig: ConfigParams): PluginInterface => {
       }));
       outputs.push(energy);
     }
-    return outputs;
+    return outputs.flat(1);
   };
 
   return {


### PR DESCRIPTION
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Enhancement (project structure, spelling, grammar, formatting)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


### A description of the changes proposed in the Pull Request
This PR integrates prometheus with IF. You can now provide inputs to IF and it will return the energy used in a k8s namespace in the output. I used the azure-importer plugin as inspiration for the parameters of the plugin.

### Config
- `kepler-observation-window`: the duration of an observation window in seconds. An input period will be split in multiple observation windows of this duration.
- `prometheus-endpoint`: the url of the prometheus server
- `kepler-namespace`: the k8s namespace to observe

### Inputs
- `timestamp`: the start of the observation period
- `duration`: the duration of the observation period in seconds

### Outputs
The same as input, with the addition of
- `energy`: the energy used by the namespace during the period in Joule.

### Example input / output
In this example, we have a period of three hours split in three observation window of one hour. This is the same behavior as the azure-importer plugin.

Input
```yaml
name: kepler-test
description:
tags:
  type: 'both'
initialize:
  outputs:
    - yaml
  plugins:
    'kepler-importer':
      path: '@grnsft/if-unofficial-plugins'
      method: KeplerPlugin
tree:
  children:
    child-1:
      pipeline:
        - kepler-importer
      config:
        kepler-importer:
          kepler-observation-window: 3600
          prometheus-endpoint: http://localhost:9090
          kepler-namespace: falco
      inputs:
        - timestamp: '2024-03-21T00:00:00Z'
          duration: 10800

```

Output
```yaml
name: kepler-test
description: null
tags: {}
initialize:
  plugins:
    kepler-importer:
      path: '@grnsft/if-unofficial-plugins'
      method: KeplerPlugin
  outputs:
    - yaml
if-version: v0.3.1
tree:
  children:
    child-1:
      pipeline:
        - kepler-importer
      config:
        kepler-importer:
          kepler-observation-window: 3600
          prometheus-endpoint: http://localhost:9090
          kepler-namespace: falco
      inputs:
        - timestamp: '2024-03-21T00:00:00Z'
          duration: 10800
      outputs:
        - timestamp: 2024-03-21T00:00:00.000Z
          energy: 327308.5421848782
          duration: 3600
        - timestamp: 2024-03-21T01:00:00.000Z
          energy: 327897.84403360804
          duration: 3600
        - timestamp: 2024-03-21T02:00:00.000Z
          energy: 327096.281344539
          duration: 3600
```

And it uses this PromQL query: `sum(increase(kepler_container_joules_total{container_namespace="falco"}[1h]))`

It still need input validation, error handling and tests, but I'm waiting on your feedback before working on it. In particular:
- Do you think namespace is a good granularity for observations? Should we provide other parameters, such as pod or container?
- Do you think it is a good idea to split one input into multiple periods, like the azure-importer plugin? Or should we stick to one output period per input period?


Closes #2 

