### PR TITLE
Forward input to the plugin output

### DIFF
--- a/kepler-manifest.yml
+++ b/kepler-manifest.yml
@@ -12,11 +12,15 @@ initialize:
     'kepler-importer':
       path: '@grnsft/if-unofficial-plugins'
       method: KeplerPlugin
+    'sci-o':
+      path: '@grnsft/if-plugins'
+      method: SciO
 tree:
   children:
     child-1:
       pipeline:
         - kepler-importer
+        - sci-o
       config:
         kepler-importer:
           kepler-observation-window: 3600
@@ -26,3 +30,4 @@ tree:
       inputs:
         - timestamp: '2024-03-21T00:00:00Z'
           duration: 10800
+          grid/carbon-intensity: 400

--- a/src/lib/kepler-importer/index.ts
+++ b/src/lib/kepler-importer/index.ts
@@ -40,6 +40,7 @@ export const KeplerPlugin = (globalConfig: ConfigParams): PluginInterface => {
         container
       );
       const energy = serie.values.map((sample: SampleValue) => ({
+        ...input,
         timestamp: sample.time,
         energy: sample.value,
         duration: step,


### PR DESCRIPTION
### A description of the changes proposed in the Pull Request
Forward input to the plugin output. 
This is needed when other plugins are used after the kepler-importer such as the SCI-O plugin.

Closes #9 