### PR TITLE
fix(lib): convert joules to kWh

### DIFF
--- a/src/lib/kepler-importer/index.ts
+++ b/src/lib/kepler-importer/index.ts
@@ -3,6 +3,7 @@ import {PluginInterface} from '../../interfaces';
 import {ConfigParams, PluginParams} from '../../types';
 import {PrometheusDriver, SampleValue} from 'prometheus-query';
 
+const J_TO_KWH = 3600000;
 export const KeplerPlugin = (globalConfig: ConfigParams): PluginInterface => {
   const metadata = {
     kind: 'execute',
@@ -42,7 +43,7 @@ export const KeplerPlugin = (globalConfig: ConfigParams): PluginInterface => {
       const energy = serie.values.map((sample: SampleValue) => ({
         ...input,
         timestamp: sample.time,
-        energy: sample.value,
+        energy: sample.value / J_TO_KWH,
         duration: step,
       }));
       outputs.push(energy);


### PR DESCRIPTION
### A description of the changes proposed in the Pull Request
Our plugin output energy in joules, but other plugin such as SCI-O expect the energy to be in kWh.
https://github.com/Green-Software-Foundation/if-plugins/tree/main/src/lib/sci-o

I changed the plugin to output energy in kWh.

Closes #17 