### PR TITLE
feat: Add SCI pipeline manifest

### DIFF
--- a/kepler-pipeline-manifest.yaml
+++ b/kepler-pipeline-manifest.yaml
@@ -1,0 +1,45 @@
+name: kepler-pipeline-test
+description:
+tags:
+initialize:
+  outputs:
+    - yaml
+  plugins:
+    'kepler-importer':
+      path: '@grnsft/if-unofficial-plugins'
+      method: KeplerPlugin
+    'sci-m':
+      path: '@grnsft/if-plugins'
+      method: SciM
+    'sci-o':
+      path: '@grnsft/if-plugins'
+      method: SciO
+    'sci':
+      path: '@grnsft/if-plugins'
+      method: Sci
+      global-config:
+        functional-unit-time: '1 hour'
+tree:
+  children:
+    child-1:
+      pipeline:
+        - kepler-importer
+        - sci-o
+        - sci-m
+        - sci
+      config:
+        sci-m:
+        sci-o:
+        kepler-importer:
+          kepler-observation-window: 3600
+          prometheus-endpoint: http://localhost:9090
+          container-namespace: falco
+          container-name: falco
+      inputs:
+        - timestamp: '2024-03-28T00:00:00Z'
+          duration: 3600
+          device/emissions-embodied: 550000 # gCO2eq https://github.com/cncf-tags/green-reviews-tooling/blob/main/docs/measurement/sci.md
+          device/expected-lifespan: 126144000 # 4 years in seconds
+          grid/carbon-intensity: 56 # France average carbon intensity 2023 gCO2eq/kWh
+          resources-reserved: 1
+          resources-total: 1


### PR DESCRIPTION
Fixes #14 

```sh
ie --manifest kepler-pipeline-manifest.yaml --verbose --output out

name: kepler-pipeline-test
description: null
tags: null
initialize:
  plugins:
    kepler-importer:
      path: '@grnsft/if-unofficial-plugins'
      method: KeplerPlugin
    sci-m:
      path: '@grnsft/if-plugins'
      method: SciM
    sci-o:
      path: '@grnsft/if-plugins'
      method: SciO
    sci:
      path: '@grnsft/if-plugins'
      method: Sci
      global-config:
        functional-unit-time: 1 hour
  outputs:
    - yaml
if-version: v0.3.1
tree:
  children:
    child-1:
      pipeline:
        - kepler-importer
        - sci-o
        - sci-m
        - sci
      config:
        sci-m: null
        sci-o: null
        kepler-importer:
          kepler-observation-window: 3600
          prometheus-endpoint: http://localhost:9090
          container-namespace: falco
          container-name: falco
      inputs:
        - timestamp: '2024-03-28T00:00:00Z'
          duration: 3600
          device/emissions-embodied: 550000
          device/expected-lifespan: 126144000
          grid/carbon-intensity: 56
          resources-reserved: 1
          resources-total: 1
      outputs:
        - timestamp: 2024-03-28T00:00:00.000Z
          duration: 3600
          device/emissions-embodied: 550000
          device/expected-lifespan: 126144000
          grid/carbon-intensity: 56
          resources-reserved: 1
          resources-total: 1
          energy: 0.00635571932773124
          carbon-operational: 0.3559202823529494
          carbon-embodied: 15.69634703196347
          carbon: 0.004458963142865672
          sci: 16.05226731431642
```