### PR TITLE
Add basic auth support

### DIFF
--- a/src/lib/kepler-importer/README.md
+++ b/src/lib/kepler-importer/README.md
@@ -1,1 +1,10 @@
 # Kepler Metrics Importer
+
+### Add credentials to `.env`
+
+Create a `.env` file in the IF project root directory. This is where you can store your prometheus authentication details if you use basic auth. Your `.env` file should look as follows:
+
+```txt
+PROMETHEUS_USERNAME: <your-prometheus-username>
+PROMETHEUS_PASSWORD: <your-pormetheus-password>
+```


### PR DESCRIPTION
### A description of the changes proposed in the Pull Request
Add the option to connect to the prometheus server using basic auth.

Closes   #13 .